### PR TITLE
Always output an xmlns attribute on namespace changes

### DIFF
--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -40,7 +40,15 @@ var serializeNamespace = function (node) {
             return attr.name;
         })
         .indexOf('xmlns') >= 0;
-    if (getTagName(node) === 'html' && !nodeHasXmlnsAttr) {
+    // Serialize the namespace as an xmlns attribute whenever the element
+    // doesn't already have one and the inherited namespace does not match
+    // the element's namespace.
+    // As a special case, always include an xmlns for html elements, in case
+    // of broken namespaceURI handling by browsers.
+    if (!nodeHasXmlnsAttr &&
+            (!node.parentNode ||
+             node.namespaceURI !== node.parentNode.namespaceURI ||
+             getTagName(node) === 'html')) {
          return ' xmlns="' + node.namespaceURI + '"';
     } else {
         return '';

--- a/tests/browserSpecs/integrationSpec.js
+++ b/tests/browserSpecs/integrationSpec.js
@@ -8,4 +8,18 @@ describe('xmlserializer', function () {
 
         expect(serializer.serializeToString(doc)).toMatch(/<title><\/title>/);
     });
+
+    it("should output xmlns attributes for namespace changes", function () {
+        var doc = document.implementation.createHTMLDocument("");
+        var div = doc.createElementNS("http://www.w3.org/1999/xhtml", "div");
+        var foreignObject =
+            doc.createElementNS("http://www.w3.org/2000/svg", "foreignObject");
+        foreignObject.appendChild(div);
+        var svg = doc.createElementNS("http://www.w3.org/2000/svg", "svg");
+        svg.appendChild(foreignObject);
+        doc.body.appendChild(svg);
+
+        expect(serializer.serializeToString(doc))
+            .toMatch(/<body><svg xmlns="http:\/\/www.w3.org\/2000\/svg"><foreignObject><div xmlns="http:\/\/www.w3.org\/1999\/xhtml"( *\/>|><\/div>)<\/foreignObject><\/svg><\/body>/);
+    });
 });


### PR DESCRIPTION
Hi @cburgmer, thanks for your work on this project.  I have been using it as part of rasterizeHTML and find it very useful with just a few issues.  This PR should address the primary one I'm experiencing:

Currently xmlserializer only outputs an `xmlns` attribute when `xmlns` appears in the `attributes` collection or the element is `<html>`.  Unfortunately, this does not work for elements which are created dynamically using `createElementNS`.  It's likely also an issue for documents where an XML parser is used (e.g. documents with an XML media type in browsers), but I have not tested it.

This pull request additionally outputs an `xmlns` attribute whenever the namespace of an element does not match the namespace of its parent (or when it doesn't have a parent from which to inherit a
namespace).  In all such cases the `xmlns` attribute is required to preserve the namespace of the element.

A proper solution for handling namespaces in XML would also need to consider the prefix->namespace mapping on each element and output appropriate prefixed `xmlns` attributes for each mapping change from the parent element.  However, since prefixes aren't currently supported (AFAICT), I've left it out of this PR.

Thanks,
Kevin
