### PR TITLE
Handle XML node name prefixes

### DIFF
--- a/tests/specs/serializerSpec.js
+++ b/tests/specs/serializerSpec.js
@@ -1,16 +1,14 @@
 var getParser = function () {
         if (typeof require !== "undefined") {
             return require('parse5');
-        } else {
-            return window.parser;
         }
+        return window.parser;
     },
     getSerializer = function () {
         if (typeof require !== "undefined") {
             return require('../../xmlserializer');
-        } else {
-            return window.xmlserializer;
         }
+        return window.xmlserializer;
     },
     parser = getParser(),
     serializer = getSerializer();
@@ -210,6 +208,33 @@ describe('xmlserializer', function () {
 
             expect(serializer.serializeToString(doc)).toEqual(withXHTMLBoilerplate('<!---->'));
         });
+    });
 
+    describe('xml namespace serialization', function () {
+        it('should prefix a namespace', function () {
+            var xmlString = '<prefixed:element><elem></elem></prefixed:element>';
+            var parsedXml = parser.parse(xmlString, 'text/xml');
+
+            expect(serializer.serializeToString(parsedXml)).toMatch('prefixed:element');
+        });
+        it('should leave missing namespace un-prefixed', function () {
+            var xmlString = '<element><elem></elem></element>';
+            var parsedXml = parser.parse(xmlString, 'text/xml');
+
+            expect(serializer.serializeToString(parsedXml)).toMatch('<element>');
+        });
+
+        it('should prefix attribute', function () {
+            var xmlString = '<xml prefixed:attribute="value"><body></body></xml>';
+            var parsedXml = parser.parse(xmlString);
+
+            expect(serializer.serializeToString(parsedXml)).toMatch('prefixed:attribute="value"');
+        });
+        it('should leave missing prefix attribute un-prefixed', function () {
+            var xmlString = '<xml attribute="value"><body></body></xml>';
+            var parsedXml = parser.parse(xmlString);
+
+            expect(serializer.serializeToString(parsedXml)).toMatch('xml attribute="value"');
+        });
     });
 });

--- a/tests/specs/serializerSpec.js
+++ b/tests/specs/serializerSpec.js
@@ -217,6 +217,12 @@ describe('xmlserializer', function () {
 
             expect(serializer.serializeToString(parsedXml)).toMatch('prefixed:element');
         });
+        it('should prefix a short tag namespace', function () {
+            var xmlString = '<prefixed:element/>';
+            var parsedXml = parser.parse(xmlString, 'text/xml');
+
+            expect(serializer.serializeToString(parsedXml)).toMatch('<prefixed:element/>');
+        });
         it('should leave missing namespace un-prefixed', function () {
             var xmlString = '<element><elem></elem></element>';
             var parsedXml = parser.parse(xmlString, 'text/xml');

--- a/xmlserializer.js
+++ b/xmlserializer.js
@@ -46,20 +46,28 @@
     };
 
     var serializeNamespace = function (node, isRootNode) {
+        var nodePrefixes = node.nodeName.match(/(.*):/);
+
+        var nodePrefix = 'xmlns';
+        if (null !== nodePrefixes && nodePrefixes.length > 0) {
+            nodePrefix = 'xmlns:' + nodePrefixes[1];
+        }
+
         var nodeHasXmlnsAttr = Array.prototype.map.call(node.attributes || node.attrs, function (attr) {
             return attr.name;
-        })
-                .indexOf('xmlns') >= 0;
+        }).indexOf(nodePrefix) >= 0;
+
         // Serialize the namespace as an xmlns attribute whenever the element
         // doesn't already have one and the inherited namespace does not match
         // the element's namespace.
-        if (!nodeHasXmlnsAttr &&
-            (isRootNode ||
-             node.namespaceURI !== node.parentNode.namespaceURI)) {
-            return ' xmlns="' + node.namespaceURI + '"';
-        } else {
-            return '';
+        if (!nodeHasXmlnsAttr
+            && (isRootNode || node.namespaceURI !== node.parentNode.namespaceURI)
+            && node.namespaceURI !== null
+        ) {
+            return ' ' + nodePrefix + '="' + node.namespaceURI + '"';
         }
+
+        return '';
     };
 
     var serializeChildren = function (node) {


### PR DESCRIPTION
Based on how `serializeNamespace` was implemented already it seems that xml is supported quite nicely already.

This PR adds some functionality and tests to allow prefixing of xml node names as well.

```
<prefix:element><child></child></prefix:element>
```
or
```
<prefix:element />
```